### PR TITLE
fix: use permutations to calculate odds

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ const result = odds([hand1, hand2], {
 
 console.log(result);
 // => [
-//      { wins: 149, ties: 0, total: 990 },
-//      { wins: 841, ties: 0, total: 990 },
+//      { wins: 304, ties: 0, total: 1980 },
+//      { wins: 1676, ties: 0, total: 1980 },
 //    ]
 ```
 

--- a/src/__tests__/odds.test.ts
+++ b/src/__tests__/odds.test.ts
@@ -17,8 +17,8 @@ describe('odds', () => {
       ];
 
       expect(odds(hands, { ...holdemOptions, communityCards: ['Qd', 'Js', '8d'] })).toEqual([
-        { wins: 149, ties: 0, total: 990 },
-        { wins: 841, ties: 0, total: 990 },
+        { wins: 304, ties: 0, total: 1980 },
+        { wins: 1676, ties: 0, total: 1980 },
       ]);
     });
 
@@ -29,8 +29,8 @@ describe('odds', () => {
       ];
 
       expect(odds(hands, { ...holdemOptions, communityCards: ['Qd', 'Js', '8h'] })).toEqual([
-        { wins: 45, ties: 900, total: 990 },
-        { wins: 45, ties: 900, total: 990 },
+        { wins: 90, ties: 1800, total: 1980 },
+        { wins: 90, ties: 1800, total: 1980 },
       ]);
     });
 
@@ -42,9 +42,9 @@ describe('odds', () => {
       ];
 
       expect(odds(hands, { ...holdemOptions, communityCards: ['Qd', 'Js', '8h'] })).toEqual([
-        { wins: 29, ties: 114, total: 903 },
-        { wins: 28, ties: 114, total: 903 },
-        { wins: 732, ties: 0, total: 903 },
+        { wins: 58, ties: 234, total: 1806 },
+        { wins: 56, ties: 234, total: 1806 },
+        { wins: 1458, ties: 0, total: 1806 },
       ]);
     });
 
@@ -52,17 +52,8 @@ describe('odds', () => {
       const hands: Hand[] = [['As', 'Ks'], ['Ad']];
 
       expect(odds(hands, { ...holdemOptions, communityCards: ['Qd', 'Js', '8h'] })).toEqual([
-        { wins: 12694, ties: 1109, total: 15180 },
-        { wins: 1377, ties: 1109, total: 15180 },
-      ]);
-    });
-
-    it('heads-up, not all hole cards provided', () => {
-      const hands: Hand[] = [['As', 'Ks'], ['Ad']];
-
-      expect(odds(hands, { ...holdemOptions, communityCards: ['Qd', 'Js', '8h'] })).toEqual([
-        { wins: 12694, ties: 1109, total: 15180 },
-        { wins: 1377, ties: 1109, total: 15180 },
+        { wins: 59072, ties: 8272, total: 91080 },
+        { wins: 23736, ties: 8272, total: 91080 },
       ]);
     });
 
@@ -92,13 +83,13 @@ describe('odds', () => {
 
     it('heads-up (no ties)', () => {
       const hands: Hand[] = [
-        ['As', 'Kd', 'Ks', '8s', 'Ac'],
-        ['9s', '8s', 'Ts', '6s', '4h'],
+        ['As', 'Kd', 'Ks', '8c', 'Ac', '2d'],
+        ['9s', '8s', 'Ts', '6s', '4h', '2c'],
       ];
 
       expect(odds(hands, studOptions)).toEqual([
-        { wins: 73732, ties: 0, total: 123410 },
-        { wins: 49678, ties: 0, total: 123410 },
+        { wins: 1206, ties: 0, total: 1560 },
+        { wins: 354, ties: 0, total: 1560 },
       ]);
     });
   });

--- a/src/__tests__/utils/getPermutations.test.ts
+++ b/src/__tests__/utils/getPermutations.test.ts
@@ -1,0 +1,108 @@
+import { getPermutations } from '../../utils/getPermutations';
+
+describe('getPermutations', () => {
+  const items = [1, 2, 3, 4, 5];
+
+  it('returns an empty array when given a count of 0 or less', () => {
+    expect(getPermutations(items, 0)).toEqual([]);
+    expect(getPermutations(items, -1)).toEqual([]);
+  });
+
+  it('returns permutations when given a count of 1', () => {
+    expect(getPermutations(items, 1)).toEqual([[1], [2], [3], [4], [5]]);
+  });
+
+  it('returns permutations when given a count of 2', () => {
+    expect(getPermutations(items, 2)).toEqual([
+      [1, 2],
+      [1, 3],
+      [1, 4],
+      [1, 5],
+      [2, 1],
+      [2, 3],
+      [2, 4],
+      [2, 5],
+      [3, 1],
+      [3, 2],
+      [3, 4],
+      [3, 5],
+      [4, 1],
+      [4, 2],
+      [4, 3],
+      [4, 5],
+      [5, 1],
+      [5, 2],
+      [5, 3],
+      [5, 4],
+    ]);
+  });
+
+  it('returns permutations when given a count of 3', () => {
+    expect(getPermutations(items, 3)).toEqual([
+      [1, 2, 3],
+      [1, 2, 4],
+      [1, 2, 5],
+      [1, 3, 2],
+      [1, 3, 4],
+      [1, 3, 5],
+      [1, 4, 2],
+      [1, 4, 3],
+      [1, 4, 5],
+      [1, 5, 2],
+      [1, 5, 3],
+      [1, 5, 4],
+      [2, 1, 3],
+      [2, 1, 4],
+      [2, 1, 5],
+      [2, 3, 1],
+      [2, 3, 4],
+      [2, 3, 5],
+      [2, 4, 1],
+      [2, 4, 3],
+      [2, 4, 5],
+      [2, 5, 1],
+      [2, 5, 3],
+      [2, 5, 4],
+      [3, 1, 2],
+      [3, 1, 4],
+      [3, 1, 5],
+      [3, 2, 1],
+      [3, 2, 4],
+      [3, 2, 5],
+      [3, 4, 1],
+      [3, 4, 2],
+      [3, 4, 5],
+      [3, 5, 1],
+      [3, 5, 2],
+      [3, 5, 4],
+      [4, 1, 2],
+      [4, 1, 3],
+      [4, 1, 5],
+      [4, 2, 1],
+      [4, 2, 3],
+      [4, 2, 5],
+      [4, 3, 1],
+      [4, 3, 2],
+      [4, 3, 5],
+      [4, 5, 1],
+      [4, 5, 2],
+      [4, 5, 3],
+      [5, 1, 2],
+      [5, 1, 3],
+      [5, 1, 4],
+      [5, 2, 1],
+      [5, 2, 3],
+      [5, 2, 4],
+      [5, 3, 1],
+      [5, 3, 2],
+      [5, 3, 4],
+      [5, 4, 1],
+      [5, 4, 2],
+      [5, 4, 3],
+    ]);
+  });
+
+  it('treats count > array length as count = array length', () => {
+    expect(getPermutations([1], 2)).toEqual([[1]]);
+  });
+});

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -74,10 +74,9 @@ const getDuplicates = (cards: Card[]): Map<Rank, Card[]> => {
   return duplicates;
 };
 
-const getOfAKinds = (cardGroups: Map<Rank, Card[]>, count: number): Card[][] => {
-  return [...cardGroups.values()]
-    .filter((cards) => cards.length === count)
-    .sort((a, b) => cardComparator(a[0], b[0]));
+const getCardsOfLength = <T>(cardGroups: Map<T, Card[]>, count: number): Card[][] => {
+  const values = [...cardGroups.values()];
+  return values.filter((cards) => cards.length === count).sort(handComparator);
 };
 
 const getFlushes = (cards: Card[]): Card[][] => {
@@ -95,7 +94,7 @@ const getFlushes = (cards: Card[]): Card[][] => {
   });
 
   // only return flushes made up of a legitimate hand size
-  return [...suitedCards.values()].filter((hand) => hand.length === HAND_SIZE).sort(handComparator);
+  return getCardsOfLength(suitedCards, HAND_SIZE);
 };
 
 const getKickers = (hand: Card[], allCards: Card[]) => {
@@ -177,10 +176,10 @@ const evaluateHand = (unsortedCards: Card[]): EvaluatedHand => {
     return { strength, hand: straightFlushes[0] };
   }
 
-  const duplicates = getDuplicates(cards);
+  const duplicates: Map<Rank, Card[]> = getDuplicates(cards);
 
   // four of a kind
-  const allQuads = getOfAKinds(duplicates, 4);
+  const allQuads = getCardsOfLength(duplicates, 4);
   if (allQuads.length > 0) {
     const quads = allQuads[0];
     const kickers = getKickers(quads, cards);
@@ -188,8 +187,8 @@ const evaluateHand = (unsortedCards: Card[]): EvaluatedHand => {
   }
 
   // full house
-  const allTrips = getOfAKinds(duplicates, 3);
-  const allPairs = getOfAKinds(duplicates, 2);
+  const allTrips = getCardsOfLength(duplicates, 3);
+  const allPairs = getCardsOfLength(duplicates, 2);
   if (allTrips.length > 0 && allPairs.length > 0) {
     return { strength: Strength.FULL_HOUSE, hand: [...allTrips[0], ...allPairs[0]] };
   }

--- a/src/odds.ts
+++ b/src/odds.ts
@@ -2,7 +2,7 @@ import { Card, Hand } from '@poker-apprentice/types';
 import { Odds, Scenario } from './types';
 import { buildScenario } from './utils/buildScenario';
 import { evaluateScenario } from './utils/evaluateScenario';
-import { getCombinations } from './utils/getCombinations';
+import { getPermutations } from './utils/getPermutations';
 import { getRemainingCardCount } from './utils/getRemainingCardCount';
 import { getRemainingCards } from './utils/getRemainingCards';
 
@@ -35,15 +35,17 @@ const getAllScenarios = ({
     expectedHoleCardCount,
   });
 
-  // Get all combinations of remaining cards that can be used.
-  const remainingCardCombinations = getCombinations(remainingCards, remainingCardCount);
+  // Get all permutations of remaining cards that can be used.  We want permutations rather than
+  // combinations because the results are different when a card ends up being treated as a hole
+  // card vs. community card.
+  const remainingCardPermutations = getPermutations(remainingCards, remainingCardCount);
 
-  if (remainingCardCombinations.length === 0) {
+  if (remainingCardPermutations.length === 0) {
     return [{ allHoleCards, communityCards }];
   }
 
   // Generate all possible hole card + community card scenarios based upon the remaining cards.
-  return remainingCardCombinations.reduce((scenarios: Scenario[], cards) => {
+  return remainingCardPermutations.reduce((scenarios: Scenario[], cards) => {
     scenarios.push(
       buildScenario({
         allHoleCards,

--- a/src/utils/getCombinations.ts
+++ b/src/utils/getCombinations.ts
@@ -12,7 +12,7 @@ export const getCombinations = <T>(sourceArray: T[], comboLength: number) => {
     const oneAwayFromComboLength = remainingCount === 1;
 
     // For each element that remaines to be added to the working combination.
-    for (let sourceIndex = currentIndex; sourceIndex < sourceLength; sourceIndex++) {
+    for (let sourceIndex = currentIndex; sourceIndex < sourceLength; sourceIndex += 1) {
       // Get next (possibly partial) combination.
       workingCombo.push(sourceArray[sourceIndex]);
 

--- a/src/utils/getPermutations.ts
+++ b/src/utils/getPermutations.ts
@@ -1,0 +1,29 @@
+// Generate all permutations of an array.
+export const getPermutations = <T>(items: T[], count: number) => {
+  const permutations: T[][] = [];
+
+  const makeNextPermutations = (workingPerm: T[], remainingCount: number) => {
+    let i = 0;
+
+    while (i < items.length) {
+      const [currentItem] = items.splice(i, 1);
+      workingPerm.push(currentItem);
+
+      if (remainingCount === 1) {
+        permutations.push([...workingPerm]);
+      } else {
+        makeNextPermutations(workingPerm, remainingCount - 1);
+      }
+
+      workingPerm.pop();
+      items.splice(i, 0, currentItem);
+      i += 1;
+    }
+  };
+
+  if (count >= 1) {
+    makeNextPermutations([], Math.min(count, items.length));
+  }
+
+  return permutations;
+};


### PR DESCRIPTION
Because undealt cards might be part of an unknown/incomplete hand OR part of the community cards, permutations (rather than combinations) must be used to test all possible scenarios.